### PR TITLE
Added applications section in .app

### DIFF
--- a/src/criswell.app.src
+++ b/src/criswell.app.src
@@ -3,5 +3,6 @@
     {vsn, git},
     {modules, []},
     {registered, [criswell_sup]},
-    {mod, {criswell_app, []}}
+    {mod, {criswell_app, []}},
+    {applications, [kernel,stdlib]}
 ]}.


### PR DESCRIPTION
Applications section is required in order to produce a release.

```
===> Errors generating release
          criswell: Missing parameter in .app file: applications
```